### PR TITLE
Don't use prefs from an empty syncfolder

### DIFF
--- a/awp/packager.py
+++ b/awp/packager.py
@@ -55,7 +55,7 @@ def get_user_prefs_dir():
             'com.runningwithcrayons.Alfred-Preferences.plist'))
 
     # If user is syncing their preferences using a syncing service
-    if 'syncfolder' in core_prefs:
+    if core_prefs.get('syncfolder'):
         return os.path.expanduser(core_prefs['syncfolder'])
     else:
         return os.path.join(


### PR DESCRIPTION
I was trying to use awp and getting an (inaccurate) error: `OSError: Workflow is not installed locally`.

This is because my prefs plist file had a syncfolder key with a blank string for a value and awp produced an incorrect path to the prefs dir:
<img width="335" alt="Screenshot 2023-11-07 at 10 05 43 AM" src="https://github.com/caleb531/alfred-workflow-packager/assets/343665/4ec699e9-59c2-4adb-83e1-f0ff7984cdcf">

In this case, we shouldn't use the empty syncfolder value. I implemented this fix locally and it resolved the error I was hitting (with no other changes).